### PR TITLE
Bug fixes and improvements for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+stats_ag CHANGELOG
+===========================
+
+
+0.1.1
+-----
+- Fixed syslog date format and example
+- Added debug option `-d`
+- Updated how flag default options are printed
+- Added `-v` option to print version info
+- Updated build script so that build version is automatically included as well as the build date and the commit hash
+
+0.1.0
+-----
+- Initial version. 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-go build -o bin/stats-ag
+echo "Building v$1"
+go build -o bin/stats-ag -ldflags "-X main.BUILD_DATE `date +%Y-%m-%d` -X main.VERSION $1 -X main.COMMIT_SHA `git rev-parse --verify HEAD`" 

--- a/custom_metric.go
+++ b/custom_metric.go
@@ -16,7 +16,7 @@ type CustomMetric struct {
 
 func NewCustomMetric(script_path string) (*CustomMetric, error) {
 
-	if debug {
+	if debug == 1 {
 		fmt.Println(getDateStamp(time_prefix), "[DEBUG] custom metric file:", script_path)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const (
-	VERSION = "0.1.1"
-)
+var VERSION string = "0.0.0"
+var BUILD_DATE string = ""
+var COMMIT_SHA string = ""


### PR DESCRIPTION
## 0.1.1
- Fixed syslog date format and example
- Added debug option `-d`
- Updated how flag default options are printed
- Added `-v` option to print version info
- Updated build script so that build version is automatically included as well as the build date and the commit hash
