### PR TITLE
V0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ stats_ag CHANGELOG
 ===========================
 
 
+0.1.2
+-----
+- Updated `gopsutil` related fuction calls to reflect the 2.0.0 [release](https://github.com/shirou/gopsutil/releases/tag/v2.0.0)
+
 0.1.1
 -----
 - Fixed syslog date format and example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ stats_ag CHANGELOG
 0.1.2
 -----
 - Updated `gopsutil` related fuction calls to reflect the 2.0.0 [release](https://github.com/shirou/gopsutil/releases/tag/v2.0.0)
+- [bugfix] If the scripts dir was specified, but scripts were not enabled, a deadlock situation would occur as the application was expecting more stats to execute then actually existed. 
+- Removed the `-e` flag to enable custome scripts as the `-s` flag with a default value of empty, makes it unecessary.  
 
 0.1.1
 -----

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+
+## Description
+
+A small process that collects and outputs system metrics to designated log files.  Also runs executable scripts, returning simple data, which are placed in the appropriate location.
+
+## Building
+
+To build the binary, use the following example:
+
+```bash
+go build -ldflags "-X main.build_date=`date +%Y-%m-%d` -X main.VERSION=X.Y.Z -X main.COMMIT_SHA=`git rev-parse --verify HEAD`" -o stats-ag
+```
+
+Or use this method to build for another OS/Architecture
+```bash
+GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.BUILD_DATE=`date +%Y-%m-%d` -X main.VERSION=X.Y.Z -X main.COMMIT_SHA=`git rev-parse --verify HEAD`" -o stats-ag
+```
+
+
+## Usage examples
+
+
+## Authors
+
+
+
+## License
+
+Convered under the MIT License

--- a/corestats.go
+++ b/corestats.go
@@ -23,7 +23,7 @@ func GetMemStats() string {
 }
 
 func GetLoadStats() string {
-	l, err := load.LoadAvg()
+	l, err := load.Avg()
 	format := "last1=%f last5=%f last15=%f"
 	if err == nil {
 		return fmt.Sprintf(format, l.Load1, l.Load5, l.Load15)
@@ -33,7 +33,7 @@ func GetLoadStats() string {
 }
 
 func GetDiskStats() string {
-	d, err := disk.DiskUsage("/")
+	d, err := disk.Usage("/")
 	format := "fstype=%s total=%d free=%d used=%d used_percent=%f inodes_total=%d inodes_used=%d inodes_free=%d inodes_used_percent=%f"
 	if err == nil {
 		return fmt.Sprintf(format,
@@ -44,7 +44,7 @@ func GetDiskStats() string {
 }
 
 func GetCpuStats() string {
-	v, err := cpu.CPUTimes(false)
+	v, err := cpu.Times(false)
 	format := "user=%f system=%f idle=%f nice=%f iowait=%f irq=%f soft_irq=%f steal=%f guest=%f guest_nice=%f stolen=%f"
 	if err == nil {
 		return fmt.Sprintf(format,
@@ -56,7 +56,7 @@ func GetCpuStats() string {
 }
 
 func GetHostStats() string {
-	v, err := host.HostInfo()
+	v, err := host.Info()
 	format := "uptime=%d procs=%d os=%s platform=%s platform_family=%s platform_version=%s virtualization_system=%s virtualization_role=%s"
 	if err == nil {
 		return fmt.Sprintf(format, v.Uptime, v.Procs, v.OS, v.Platform, v.PlatformFamily, v.PlatformVersion, v.VirtualizationSystem, v.VirtualizationRole)
@@ -66,7 +66,7 @@ func GetHostStats() string {
 }
 
 func GetNetStats() string {
-	v, err := net.NetIOCounters(false)
+	v, err := net.IOCounters(false)
 	format := "bytes_sent=%d bytes_recv=%d packets_sent=%d packets_recv=%d err_in=%d err_out=%d drop_in=%d drop_out=%d"
 	if err == nil {
 		return fmt.Sprintf(format, v[0].BytesSent, v[0].BytesRecv, v[0].PacketsSent, v[0].PacketsRecv, v[0].Errin, v[0].Errout, v[0].Dropin, v[0].Dropout)


### PR DESCRIPTION
- [bugfix] Updated `gopsutil` related fuction calls to reflect the 2.0.0 [release](https://github.com/shirou/gopsutil/releases/tag/v2.0.0).  Building the current binary, without `gopsutil` already present in the go library, would fail.
- [bugfix] If the scripts dir was specified, but scripts were not enabled, a deadlock situation would occur as the application was expecting more stats to execute then actually existed. 
- [improvement] Removed the `-e` flag to enable custome scripts as the `-s` flag with a default value of empty, makes it unecessary.
